### PR TITLE
Fix multimedia keys on xS60 fork

### DIFF
--- a/tmk_core/common/keymap.c
+++ b/tmk_core/common/keymap.c
@@ -142,7 +142,7 @@ static action_t keycode_to_action(uint8_t keycode)
         case KC_SYSTEM_POWER ... KC_SYSTEM_WAKE:
             action.code = ACTION_USAGE_SYSTEM(KEYCODE2SYSTEM(keycode));
             break;
-        case KC_AUDIO_MUTE ... KC_MEDIA_REWIND:
+        case KC_AUDIO_MUTE ... KC_WWW_FAVORITES:
             action.code = ACTION_USAGE_CONSUMER(KEYCODE2CONSUMER(keycode));
             break;
         case KC_MS_UP ... KC_MS_ACCEL2:


### PR DESCRIPTION
I was trying to track down why play/pause was not working for me and I compared your fork with tmk/tmk_keyboard/master until I could find something odd. Turns out you constrained a range for apparently no particular reason.

I tried with the broader range and found out everything works perfectly for me since. I hope this helps the community.
